### PR TITLE
Fixed invalid data insertion Bug.

### DIFF
--- a/app/src/main/java/com/example/android/pets/data/PetProvider.java
+++ b/app/src/main/java/com/example/android/pets/data/PetProvider.java
@@ -156,7 +156,7 @@ public class PetProvider extends ContentProvider {
 
         // If the weight is provided, check that it's greater than or equal to 0 kg
         Integer weight = values.getAsInteger(PetEntry.COLUMN_PET_WEIGHT);
-        if (weight != null && weight < 0) {
+        if (weight == null || weight < 0) {
             throw new IllegalArgumentException("Pet requires valid weight");
         }
 
@@ -228,7 +228,7 @@ public class PetProvider extends ContentProvider {
         if (values.containsKey(PetEntry.COLUMN_PET_WEIGHT)) {
             // Check that the weight is greater than or equal to 0 kg
             Integer weight = values.getAsInteger(PetEntry.COLUMN_PET_WEIGHT);
-            if (weight != null && weight < 0) {
+            if (weight == null || weight < 0) {
                 throw new IllegalArgumentException("Pet requires valid weight");
             }
         }


### PR DESCRIPTION
>>  (weight != null && weight < 0) 
This allowed user to insert 0 or null as acceptable values into database as AND operator is used instead of OR. Since exception isn't thrown unless both conditions are true. Also wrong equality operator is used for checking weight being equal to null.